### PR TITLE
Added option to display branch name in comment and to get task id from current branch name

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ Then chmod your hooks folder:
 
 Now in your commits, you can write messages like "Tweaked the widget; fixed #1, #2, and #3; references #4 and #5; oh yeah, and closes #6" and the right thing will happen.
 
-
+In addition, two variables exist in the post-commit script:
+display_branch_name (default true) - set to true for displaying the branch name after the repository in the comment.
+comment_by_branch_task_id (default true) - set to true for checking the branch name for task id. The task id must be start with '#' and be in the last part of the name. Example for branch name: `%myBranch#1`
 
 LICENSE
 -------

--- a/post-commit
+++ b/post-commit
@@ -12,6 +12,8 @@
 # -----------------------
 
 apikey=$(git config user.asana-key)
+display_branch_name=true
+comment_by_branch_task_id=true
 if [ $apikey == '' ] ; then exit 0; fi
 
 # hold the closed ticket numbers
@@ -31,9 +33,17 @@ and_pattern='([Aa]nd|&)'
 # get the checkin comment for parsing
 comment=$(git log --pretty=format:"%s %b" -n1)
 repo=${PWD##*/}
+
+# get branch name and display in the comment
+branch_message=""
+if [ "$display_branch_name" = true ]; then
+    branch=$(git branch | grep '*' | sed 's/^..//')
+    branch_message=" in branch $branch"
+fi
+
 print_comment=$(git log --pretty=format:"Just committed %h with message:
 \"%s\"
-to repository $repo" -n1)
+to repository $repo$branch_message" -n1)
 
 # break the commit comment down into words
 IFS=' ' read -a words <<< "$comment"
@@ -42,19 +52,26 @@ for element in "${words[@]}"
 do
     # if we have a task id, save it to the appropriate array
     if [[ $element =~ $taskid_pattern ]]; then
-	if [ "${closes}" == "YES" ]; then
-	    closed=("${closed[@]}" "${BASH_REMATCH[1]}")
-	fi
-	referenced=("${referenced[@]}" "${BASH_REMATCH[1]}")
+        if [ "${closes}" == "YES" ]; then
+            closed=("${closed[@]}" "${BASH_REMATCH[1]}")
+        fi
+        referenced=("${referenced[@]}" "${BASH_REMATCH[1]}")
     # or else if we have a "closes" word, set the tracking bool accordingly
     elif [[ $element =~ $closes_pattern ]]; then
-	closes='YES'
+        closes='YES'
     # and if we don't, set us back to referencing
     # (if we're an "and", don't change any state)
     elif [[ ! $element =~ $and_pattern ]]; then
-	closes='NO'
+        closes='NO'
     fi
 done
+
+# get task id from branch name. Then send a comment request if task_id exists
+task_id=$(git branch | grep '*' | sed 's/^..//' | grep -o '#.*' | sed 's/^.//')
+if [[ "$task_id" && "$comment_by_branch_task_id" = true ]]; then
+    curl -u ${apikey}: https://app.asana.com/api/1.0/tasks/${task_id}/stories \
+         -d "text=${print_comment}" > /dev/null 2>&1
+fi
 
 # touch the stories we've referenced
 for element in "${referenced[@]}"


### PR DESCRIPTION
- Added an option (default: true) to get task id from branch name and send comment.
- Added an option (default: true) to also display branch name in comment after repository.
- Updated README.md.
* This has been test with all possible true/false option combinations