### PR TITLE
Add Bit Bucket URLs and Asana Token API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 README
 ======
 
-A git post-commit script to comment on / close Asana tickets. Read the blog post with more detail here: [http://www.ultrajoke.net/2013/01/integrating-asana-and-git/](http://www.ultrajoke.net/2013/01/integrating-asana-and-git/)
+A git post-commit script to comment on / close Asana tickets. Read the blog post about version one here: [http://www.ultrajoke.net/2013/01/integrating-asana-and-git/](http://www.ultrajoke.net/2013/01/integrating-asana-and-git/)
 
 tl;dr:
 
@@ -9,12 +9,12 @@ Copy the post-commit file to your repo's root `.git/hooks` directory. It's proba
 
 Then run the following commands:
 
-`% git config --global user.asana-key "MY_ASANA_API_KEY" # (get the api key at http://app.asana.com/-/account_api)`
+`% git config --global user.asana-token "MY_ASANA_PERSONAL_ACCESS_TOKEN" (http://app.asana.com/-/account_api)`
 
 `% git config --global user.display-branch-name-in-comment "true/false" # (This is config is optional, defaults to false)` 
 
-Then chmod your hooks folder:
-`% chmod 655 .git/hooks`
+Then chmod your hooks folder and post-commit hook file:
+`% chmod 755 .git/hooks && chmod ogu+rx .git/hooks/post-commit`
 
 Now in your commits, you can write messages like "Tweaked the widget; fixed #1, #2, and #3; references #4 and #5; oh yeah, and closes #6" and the right thing will happen.
 

--- a/post-commit
+++ b/post-commit
@@ -17,7 +17,7 @@ display_branch_name=$(git config user.display-branch-name-in-comment)
 
 # defaults
 if [ $access_token == "" ]; then
-    echo "Please Set Your Asana Token git config --global user.asana-token \"MY_ASANA_PERSONAL_ACCESS_TOKEN\" (http://app.asana.com/-/account_api)" > &2
+    echo "Please Set Your Asana Token git config --global user.asana-token \"MY_ASANA_PERSONAL_ACCESS_TOKEN\" (http://app.asana.com/-/account_api)" >&2
     exit 1
 fi
 if [ "$display_branch_name" == "" ]; then

--- a/post-commit
+++ b/post-commit
@@ -1,24 +1,48 @@
 #!/bin/bash
 
 # modified from http://brunohq.com/journal/speed-project-git-hook-for-asana/
+#
+# Added Bitbucket and GitHub links to Asana commits
+# modified by Richard Sumilang <me@richardsumilang.com>
+# modified by Andrew Bennett <andrew@pixid.com>
 
 # -----------------------
 # necessary configuration:
-# git config --global user.asana-key "MY_ASANA_API_KEY" (http://app.asana.com/-/account_api)
-#
-# not necessary at the moment, but may be useful in future revisions of the script:
-# git config --local user.asana-workspace "WORKSPACE_ID" (found in the URL)
-# git config --local user.asana-project "PROJECT_ID" (found in the URL)
+# git config --global user.asana-token "MY_ASANA_PERSONAL_ACCESS_TOKEN" (http://app.asana.com/-/account_api)
 # -----------------------
 
-apikey=$(git config user.asana-key)
-display_branch_name=$(git config user.display-branch-name-in-comment)
-if [ "$apikey" == "" ]; then
-	exit 0;
+access_token=$(git config user.asana-token)
+
+# defaults
+if [ $access_token == "" ]; then
+    exit 0
 fi
-if [ "$display_branch_name" == "" ]; then
-	display_branch_name=false;
-fi
+
+# Find repository host
+for repository in $(git remote -v | awk '{ print $2 }'); do
+    scheme="$(echo $repository | grep :// | sed -e's,^\(.*://\).*,\1,g')"
+    url="$(echo ${repository/$scheme/})"
+    user="$(echo $url | grep @ | cut -d@ -f1)"
+    if [[ $scheme == "" ]]; then
+        host="$(echo ${url/$user@/} | cut -d: -f1)"
+        path="$(echo $url | grep : | cut -d: -f2-)"
+    else
+        host="$(echo ${url/$user@/} | cut -d/ -f1)"
+        path="$(echo $url | grep / | cut -d/ -f2-)"
+    fi
+    project="$(echo ${path%.*})"
+
+    # Bitbucket or GitHub
+    if [[ $host == "bitbucket.org" ]]; then
+        commit_url="https://bitbucket.org/$project/commits/"
+        break;
+    elif [[ $host == "github.com" ]]; then
+        commit_url="https://github.com/$project/commit/"
+        break;
+    else
+        commit_url=""
+    fi
+done
 
 # hold the closed ticket numbers
 declare -a closed
@@ -35,19 +59,12 @@ closes_pattern='([Ff]ix|[Cc]lose|[Cc]losing)'
 and_pattern='([Aa]nd|&)'
 
 # get the checkin comment for parsing
-comment=$(git log --pretty=format:"%s %b" -n1)
-repo=${PWD##*/}
-
-# get branch name and display in the comment
-branch_message=""
-if [ "$display_branch_name" == "true" ]; then
-    branch=$(git branch | grep '*' | sed 's/^..//')
-    branch_message=" in branch $branch"
+comment=$(git log --pretty=format:"%B" -n1 | tr '\n' ' ')
+if [[ $commit_url == "" ]]; then
+    print_comment=$(git log -n1 --pretty=format:"Committed %h to $(git rev-parse --abbrev-ref --quiet HEAD) on $repository:%n<code>%B</code>")
+else
+    print_comment=$(git log -n1 --pretty=format:"Committed to $(git rev-parse --abbrev-ref --quiet HEAD): $commit_url%H%n<code>%B</code>")
 fi
-
-print_comment=$(git log --pretty=format:"Just committed %h with message:
-\"%s\"
-to repository $repo$branch_message" -n1)
 
 # break the commit comment down into words
 IFS=' ' read -a words <<< "$comment"
@@ -83,16 +100,22 @@ if [ "$found_task_id" = false ]; then
 fi
 
 # touch the stories we've referenced
-for element in "${referenced[@]}"
-do
-    curl -u ${apikey}: https://app.asana.com/api/1.0/tasks/${element}/stories \
-         -d "text=${print_comment}" > /dev/null 2>&1
+for element in "${referenced[@]}"; do
+    curl \
+        -H "Authorization: Bearer ${access_token}" \
+        -X POST \
+        --data-urlencode "html_text=${print_comment}" \
+        "https://app.asana.com/api/1.0/tasks/${element}/stories" \
+        > /dev/null 2>&1
 done
 
 # close the tasks we've fixed
 for element in "${closed[@]}"
 do
-    curl --request PUT -u ${apikey}: https://app.asana.com/api/1.0/tasks/${element} \
-         -d "completed=true" > /dev/null 2>&1
+    curl \
+        -H "Authorization: Bearer ${access_token}" \
+        -X PUT \
+        --data-urlencode "completed=true" \
+        "https://app.asana.com/api/1.0/tasks/${element}" \
+        > /dev/null 2>&1
 done
-

--- a/post-commit
+++ b/post-commit
@@ -9,13 +9,19 @@
 # -----------------------
 # necessary configuration:
 # git config --global user.asana-token "MY_ASANA_PERSONAL_ACCESS_TOKEN" (http://app.asana.com/-/account_api)
+# git config --global user.display-branch-name-in-comment "true/false" # (This is config is optional, defaults to false)
 # -----------------------
 
 access_token=$(git config user.asana-token)
+display_branch_name=$(git config user.display-branch-name-in-comment)
 
 # defaults
 if [ $access_token == "" ]; then
-    exit 0
+    echo "Please Set Your Asana Token git config --global user.asana-token \"MY_ASANA_PERSONAL_ACCESS_TOKEN\" (http://app.asana.com/-/account_api)" > &2
+    exit 1
+fi
+if [ "$display_branch_name" == "" ]; then
+	display_branch_name=false;
 fi
 
 # Find repository host
@@ -60,10 +66,17 @@ and_pattern='([Aa]nd|&)'
 
 # get the checkin comment for parsing
 comment=$(git log --pretty=format:"%B" -n1 | tr '\n' ' ')
+
+branch_message=""
+if [ "$display_branch_name" == "true" ]; then
+    branch=$(git rev-parse --abbrev-ref --quiet HEAD)
+    branch_message=" in branch $branch"
+fi
+
 if [[ $commit_url == "" ]]; then
-    print_comment=$(git log -n1 --pretty=format:"Committed %h to $(git rev-parse --abbrev-ref --quiet HEAD) on $repository:%n<code>%B</code>")
+    print_comment=$(git log -n1 --pretty=format:"Committed %h$branch_message on $repository:%n<code>%B</code>")
 else
-    print_comment=$(git log -n1 --pretty=format:"Committed to $(git rev-parse --abbrev-ref --quiet HEAD): $commit_url%H%n<code>%B</code>")
+    print_comment=$(git log -n1 --pretty=format:"Committed$branch_message: $commit_url%H%n<code>%B</code>")
 fi
 
 # break the commit comment down into words


### PR DESCRIPTION
This integrates: https://github.com/Spaceman-Labs/asana-post-commit/pull/3 and https://github.com/potatosalad/asana-post-commit/commit/cd128f7271d921eda19c0e3cc1fb8c9bf7ae5ce8 without removing branch ticket detection or the setting to optionally include the branch.

It does switch the API to Asana's new token API which is backwards breaking, but it will print instructions if that is missing to provide minimal user hassle.