### PR TITLE
Wrapped commit comment in a root '<body>' tag to fix the breaking API…

### DIFF
--- a/post-commit
+++ b/post-commit
@@ -74,9 +74,9 @@ if [ "$display_branch_name" == "true" ]; then
 fi
 
 if [[ $commit_url == "" ]]; then
-    print_comment=$(git log -n1 --pretty=format:"Committed %h$branch_message on $repository:%n<code>%B</code>")
+    print_comment=$(git log -n1 --pretty=format:"<body>Committed %h$branch_message on $repository:%n<code>%B</code></body>")
 else
-    print_comment=$(git log -n1 --pretty=format:"Committed$branch_message: $commit_url%H%n<code>%B</code>")
+    print_comment=$(git log -n1 --pretty=format:"<body>Committed$branch_message: $commit_url%H%n<code>%B</code></body>")
 fi
 
 # break the commit comment down into words


### PR DESCRIPTION
… change (New Rich Text): https://asana.com/developers/news/new-rich-text

---

Without closing a task is still possible, but no comment will be posted to Asana because of error:html_lacks_body.